### PR TITLE
Exclude flyway table by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ tasks {
         inputDirectory.setFrom(project.files("src/main/resources/db/migration"))
         outputDirectory.set(project.layout.buildDirectory.dir("generated-jooq"))
         flywayProperties.put("flyway.placeholderReplacement", "false")
-        excludeFlywayTable.set(true)
+        includeFlywayTable.set(true)
         outputSchemaToDefault.add("public")
         schemaToPackageMapping.put("public", "fancy_name")
         usingJavaConfig {

--- a/src/test/kotlin/dev/monosoul/jooq/functional/CacheJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/CacheJooqDockerPluginFunctionalTest.kt
@@ -57,9 +57,6 @@ class CacheJooqDockerPluginFunctionalTest : JooqDockerPluginFunctionalTestBase()
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
             ).exists()
             that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
-            ).exists()
-            that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Bar.java")
             ).exists()
         }

--- a/src/test/kotlin/dev/monosoul/jooq/functional/ConfigurabilityJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/ConfigurabilityJooqDockerPluginFunctionalTest.kt
@@ -49,9 +49,6 @@ class ConfigurabilityJooqDockerPluginFunctionalTest : JooqDockerPluginFunctional
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/other/tables/Bar.java")
             ).exists()
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/public_/tables/FlywaySchemaHistory.java")
-            ).exists()
         }
     }
 
@@ -219,9 +216,6 @@ class ConfigurabilityJooqDockerPluginFunctionalTest : JooqDockerPluginFunctional
             that(result).generateJooqClassesTask.outcome isEqualTo SUCCESS
             that(
                 projectFile("build/gen/org/jooq/generated/tables/Foo.java")
-            ).exists()
-            that(
-                projectFile("build/gen/org/jooq/generated/tables/FlywaySchemaHistory.java")
             ).exists()
         }
     }

--- a/src/test/kotlin/dev/monosoul/jooq/functional/FlywayConfigurationJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/FlywayConfigurationJooqDockerPluginFunctionalTest.kt
@@ -65,6 +65,7 @@ class FlywayConfigurationJooqDockerPluginFunctionalTest : JooqDockerPluginFuncti
                 tasks {
                     generateJooqClasses {
                         schemas.set(listOf("other", "public"))
+                        includeFlywayTable.set(true)
                     }
                 }
 

--- a/src/test/kotlin/dev/monosoul/jooq/functional/FlywayVersionConfigurationJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/FlywayVersionConfigurationJooqDockerPluginFunctionalTest.kt
@@ -43,9 +43,6 @@ class FlywayVersionConfigurationJooqDockerPluginFunctionalTest : JooqDockerPlugi
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
             ).exists()
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
-            ).exists()
         }
     }
 
@@ -82,9 +79,6 @@ class FlywayVersionConfigurationJooqDockerPluginFunctionalTest : JooqDockerPlugi
             }
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
-            ).exists()
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
             ).exists()
         }
     }

--- a/src/test/kotlin/dev/monosoul/jooq/functional/GroovyBuildscriptJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/GroovyBuildscriptJooqDockerPluginFunctionalTest.kt
@@ -228,6 +228,7 @@ class GroovyBuildscriptJooqDockerPluginFunctionalTest : JooqDockerPluginFunction
                 tasks.register('generateJooqClassesForExternal', GenerateJooqClassesTask) {
                     basePackageName.set("org.jooq.generated.remote")
                     outputDirectory.set(project.layout.buildDirectory.dir("remote"))
+                    includeFlywayTable.set(true)
                     
                     withoutContainer {
                         db {
@@ -258,9 +259,6 @@ class GroovyBuildscriptJooqDockerPluginFunctionalTest : JooqDockerPluginFunction
             that(result).generateJooqClassesTask.outcome isEqualTo SUCCESS
             that(
                 projectFile("build/local/org/jooq/generated/local/tables/Foo.java")
-            ).exists()
-            that(
-                projectFile("build/local/org/jooq/generated/local/tables/FlywaySchemaHistory.java")
             ).exists()
             that(
                 projectFile("build/remote/org/jooq/generated/remote/tables/Foo.java")

--- a/src/test/kotlin/dev/monosoul/jooq/functional/JavaBasedConfigJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/JavaBasedConfigJooqDockerPluginFunctionalTest.kt
@@ -93,9 +93,6 @@ class JavaBasedConfigJooqDockerPluginFunctionalTest : JooqDockerPluginFunctional
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
             ).exists()
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
-            ).exists()
         }
     }
 }

--- a/src/test/kotlin/dev/monosoul/jooq/functional/JooqVersionConfigurationJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/JooqVersionConfigurationJooqDockerPluginFunctionalTest.kt
@@ -43,9 +43,6 @@ class JooqVersionConfigurationJooqDockerPluginFunctionalTest : JooqDockerPluginF
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
             ).exists()
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
-            ).exists()
         }
     }
 
@@ -82,11 +79,6 @@ class JooqVersionConfigurationJooqDockerPluginFunctionalTest : JooqDockerPluginF
             }
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
-            ).exists().and {
-                get { readText() } contains "jOOQ version:$jooqVersion"
-            }
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
             ).exists().and {
                 get { readText() } contains "jOOQ version:$jooqVersion"
             }

--- a/src/test/kotlin/dev/monosoul/jooq/functional/MultipleDatabasesJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/MultipleDatabasesJooqDockerPluginFunctionalTest.kt
@@ -37,6 +37,7 @@ class MultipleDatabasesJooqDockerPluginFunctionalTest : JooqDockerPluginFunction
                         basePackageName.set("org.jooq.generated.mysql")
                         inputDirectory.setFrom("src/main/resources/mysql/migration")
                         outputDirectory.set(project.layout.buildDirectory.dir("mysql"))
+                        includeFlywayTable.set(true)
                     
                         withContainer {
                             image {
@@ -81,9 +82,6 @@ class MultipleDatabasesJooqDockerPluginFunctionalTest : JooqDockerPluginFunction
             that(result).generateJooqClassesTask.outcome isEqualTo SUCCESS
             that(
                 projectFile("build/postgres/org/jooq/generated/postgres/tables/Foo.java")
-            ).exists()
-            that(
-                projectFile("build/postgres/org/jooq/generated/postgres/tables/FlywaySchemaHistory.java")
             ).exists()
             that(
                 projectFile("build/mysql/org/jooq/generated/mysql/tables/Foo.java")
@@ -247,6 +245,7 @@ class MultipleDatabasesJooqDockerPluginFunctionalTest : JooqDockerPluginFunction
                     register<GenerateJooqClassesTask>("generateJooqClassesForExternal") {
                         basePackageName.set("org.jooq.generated.remote")
                         outputDirectory.set(project.layout.buildDirectory.dir("remote"))
+                        includeFlywayTable.set(true)
                     
                         withoutContainer {
                             db {
@@ -278,9 +277,6 @@ class MultipleDatabasesJooqDockerPluginFunctionalTest : JooqDockerPluginFunction
             that(result).generateJooqClassesTask.outcome isEqualTo SUCCESS
             that(
                 projectFile("build/local/org/jooq/generated/local/tables/Foo.java")
-            ).exists()
-            that(
-                projectFile("build/local/org/jooq/generated/local/tables/FlywaySchemaHistory.java")
             ).exists()
             that(
                 projectFile("build/remote/org/jooq/generated/remote/tables/Foo.java")

--- a/src/test/kotlin/dev/monosoul/jooq/functional/PropertiesConfigurationJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/PropertiesConfigurationJooqDockerPluginFunctionalTest.kt
@@ -54,9 +54,6 @@ class PropertiesConfigurationJooqDockerPluginFunctionalTest : JooqDockerPluginFu
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
             ).exists()
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
-            ).exists()
         }
     }
 
@@ -100,9 +97,6 @@ class PropertiesConfigurationJooqDockerPluginFunctionalTest : JooqDockerPluginFu
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
             ).exists()
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
-            ).exists()
         }
     }
 
@@ -145,9 +139,6 @@ class PropertiesConfigurationJooqDockerPluginFunctionalTest : JooqDockerPluginFu
             that(result).generateJooqClassesTask.outcome isEqualTo SUCCESS
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
-            ).exists()
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
             ).exists()
         }
     }

--- a/src/test/kotlin/dev/monosoul/jooq/functional/RunContainerWithCommandJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/RunContainerWithCommandJooqDockerPluginFunctionalTest.kt
@@ -49,9 +49,6 @@ class RunContainerWithCommandJooqDockerPluginFunctionalTest : JooqDockerPluginFu
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
             ).exists()
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
-            ).exists()
         }
     }
 }

--- a/src/test/kotlin/dev/monosoul/jooq/functional/RunWithExternalDatabaseJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/RunWithExternalDatabaseJooqDockerPluginFunctionalTest.kt
@@ -64,9 +64,6 @@ class RunWithExternalDatabaseJooqDockerPluginFunctionalTest : JooqDockerPluginFu
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
             ).exists()
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
-            ).exists()
         }
     }
 }

--- a/src/test/kotlin/dev/monosoul/jooq/functional/SchemaVersionJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/SchemaVersionJooqDockerPluginFunctionalTest.kt
@@ -25,6 +25,7 @@ class SchemaVersionJooqDockerPluginFunctionalTest : JooqDockerPluginFunctionalTe
                 tasks {
                     generateJooqClasses {
                         flywayProperties.put("flyway.table", "some_schema_table")
+                        includeFlywayTable.set(true)
                     }
                 }
 
@@ -83,11 +84,6 @@ class SchemaVersionJooqDockerPluginFunctionalTest : JooqDockerPluginFunctionalTe
             }
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Bar.java")
-            ).exists().and {
-                get { readText() } contains "schema version:02"
-            }
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
             ).exists().and {
                 get { readText() } contains "schema version:02"
             }

--- a/src/test/kotlin/dev/monosoul/jooq/functional/ZeroConfigurationJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/ZeroConfigurationJooqDockerPluginFunctionalTest.kt
@@ -37,9 +37,6 @@ class ZeroConfigurationJooqDockerPluginFunctionalTest : JooqDockerPluginFunction
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")
             ).exists()
-            that(
-                projectFile("build/generated-jooq/org/jooq/generated/tables/FlywaySchemaHistory.java")
-            ).exists()
         }
     }
 }


### PR DESCRIPTION
Changes the plugin's default behavior to exclude Flyway history table