### PR TITLE
fix: disable test fixtures publishing

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -22,6 +22,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: check jacocoTestReport
+      - name: Test publishing
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publishToMavenLocal
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails

--- a/.github/workflows/build-on-push-to-main.yml
+++ b/.github/workflows/build-on-push-to-main.yml
@@ -19,6 +19,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: check jacocoTestReport
+      - name: Test publishing
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publishToMavenLocal
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,10 @@ plugins {
     `java-test-fixtures`
 }
 
-// disable test fixtures publishing
+/**
+ * disable test fixtures publishing
+ * https://docs.gradle.org/current/userguide/java_testing.html#publishing_test_fixtures
+ */
 val javaComponent = components["java"] as AdhocComponentWithVariants
 javaComponent.withVariantsFromConfiguration(configurations["testFixturesApiElements"]) { skip() }
 javaComponent.withVariantsFromConfiguration(configurations["testFixturesRuntimeElements"]) { skip() }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,11 @@ plugins {
     `java-test-fixtures`
 }
 
+// disable test fixtures publishing
+val javaComponent = components["java"] as AdhocComponentWithVariants
+javaComponent.withVariantsFromConfiguration(configurations["testFixturesApiElements"]) { skip() }
+javaComponent.withVariantsFromConfiguration(configurations["testFixturesRuntimeElements"]) { skip() }
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
Test fixtures weren't supposed to be published in the first place. But also release build was failing because of the dependency configuration there.

```
> Invalid publication 'pluginMaven':
    - Variant 'testFixturesApiElements' contains a dependency on enforced platform 'org.junit:junit-bom'
    - Variant 'testFixturesRuntimeElements' contains a dependency on enforced platform 'org.junit:junit-bom'
```

https://github.com/monosoul/jooq-gradle-plugin/runs/8207518392?check_suite_focus=true