### PR TITLE
fix: deprecated features usages

### DIFF
--- a/extra-tests/src/test/kotlin/dev/monosoul/jooq/functional/ConfigurationCacheJooqDockerPluginFunctionalTest.kt
+++ b/extra-tests/src/test/kotlin/dev/monosoul/jooq/functional/ConfigurationCacheJooqDockerPluginFunctionalTest.kt
@@ -51,7 +51,9 @@ class ConfigurationCacheJooqDockerPluginFunctionalTest : FunctionalTestBase() {
             }
             that(resultFromCache).apply {
                 generateJooqClassesTask.outcome isEqualTo UP_TO_DATE
-                get { output }.contains("Configuration cache entry reused")
+                get { output }.contains("Configuration cache entry reused") not {
+                    contains("Deprecated Gradle features were used in this build")
+                }
             }
             that(
                 projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java")

--- a/src/main/kotlin/dev/monosoul/jooq/GenerateJooqClassesTask.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/GenerateJooqClassesTask.kt
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -123,7 +124,7 @@ open class GenerateJooqClassesTask @Inject constructor(
      *
      * Avoid changing manually, use [withContainer] or [withoutContainer] instead.
      */
-    @Input
+    @Nested
     fun getPluginSettings() = localPluginSettings ?: globalPluginSettings.get()
 
     private val migrationRunner = UniversalMigrationRunner(schemas, inputDirectory, flywayProperties)

--- a/src/main/kotlin/dev/monosoul/jooq/settings/Database.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/settings/Database.kt
@@ -3,37 +3,43 @@ package dev.monosoul.jooq.settings
 import org.gradle.api.Action
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.Internal as GradleInternal
 
 sealed class Database : JdbcAware, SettingsElement {
+    @get:Input
     abstract var username: String
+
+    @get:Input
     abstract var password: String
+
+    @get:Input
     abstract var name: String
+
+    @get:Input
     abstract var port: Int
+
+    @get:Nested
     internal abstract val jdbc: Jdbc
 
     override fun jdbc(customizer: Action<Jdbc>) = customizer.execute(jdbc)
 
     data class Internal(
-        @get:Input override var username: String = "postgres",
-        @get:Input override var password: String = "postgres",
-        @get:Input override var name: String = "postgres",
-        @get:Input override var port: Int = 5432,
-        @get:Nested override val jdbc: Jdbc = Jdbc(),
+        override var username: String = "postgres",
+        override var password: String = "postgres",
+        override var name: String = "postgres",
+        override var port: Int = 5432,
+        override val jdbc: Jdbc = Jdbc(),
     ) : Database() {
-        @GradleInternal
         internal fun getJdbcUrl(host: String, port: Int) = "${jdbc.schema}://$host:$port/$name${jdbc.urlQueryParams}"
     }
 
     data class External(
-        @get:Input override var username: String = "postgres",
-        @get:Input override var password: String = "postgres",
-        @get:Input override var name: String = "postgres",
+        override var username: String = "postgres",
+        override var password: String = "postgres",
+        override var name: String = "postgres",
         @get:Input var host: String = "localhost",
-        @get:Input override var port: Int = 5432,
-        @get:Nested override val jdbc: Jdbc = Jdbc(),
+        override var port: Int = 5432,
+        override val jdbc: Jdbc = Jdbc(),
     ) : Database() {
-        @GradleInternal
         internal fun getJdbcUrl() = "${jdbc.schema}://$host:$port/$name${jdbc.urlQueryParams}"
     }
 }

--- a/src/main/kotlin/dev/monosoul/jooq/settings/Database.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/settings/Database.kt
@@ -1,6 +1,8 @@
 package dev.monosoul.jooq.settings
 
 import org.gradle.api.Action
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
 
 sealed class Database : JdbcAware, SettingsElement {
     abstract var username: String
@@ -12,22 +14,22 @@ sealed class Database : JdbcAware, SettingsElement {
     override fun jdbc(customizer: Action<Jdbc>) = customizer.execute(jdbc)
 
     data class Internal(
-        override var username: String = "postgres",
-        override var password: String = "postgres",
-        override var name: String = "postgres",
-        override var port: Int = 5432,
-        override val jdbc: Jdbc = Jdbc(),
+        @get:Input override var username: String = "postgres",
+        @get:Input override var password: String = "postgres",
+        @get:Input override var name: String = "postgres",
+        @get:Input override var port: Int = 5432,
+        @get:Nested override val jdbc: Jdbc = Jdbc(),
     ) : Database() {
         internal fun getJdbcUrl(host: String, port: Int) = "${jdbc.schema}://$host:$port/$name${jdbc.urlQueryParams}"
     }
 
     data class External(
-        override var username: String = "postgres",
-        override var password: String = "postgres",
-        override var name: String = "postgres",
-        var host: String = "localhost",
-        override var port: Int = 5432,
-        override val jdbc: Jdbc = Jdbc(),
+        @get:Input override var username: String = "postgres",
+        @get:Input override var password: String = "postgres",
+        @get:Input override var name: String = "postgres",
+        @get:Input var host: String = "localhost",
+        @get:Input override var port: Int = 5432,
+        @get:Nested override val jdbc: Jdbc = Jdbc(),
     ) : Database() {
         internal fun getJdbcUrl() = "${jdbc.schema}://$host:$port/$name${jdbc.urlQueryParams}"
     }

--- a/src/main/kotlin/dev/monosoul/jooq/settings/Database.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/settings/Database.kt
@@ -3,6 +3,7 @@ package dev.monosoul.jooq.settings
 import org.gradle.api.Action
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Internal as GradleInternal
 
 sealed class Database : JdbcAware, SettingsElement {
     @get:Input
@@ -40,6 +41,7 @@ sealed class Database : JdbcAware, SettingsElement {
         override var port: Int = 5432,
         override val jdbc: Jdbc = Jdbc(),
     ) : Database() {
+        @GradleInternal
         internal fun getJdbcUrl() = "${jdbc.schema}://$host:$port/$name${jdbc.urlQueryParams}"
     }
 }

--- a/src/main/kotlin/dev/monosoul/jooq/settings/Database.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/settings/Database.kt
@@ -3,6 +3,7 @@ package dev.monosoul.jooq.settings
 import org.gradle.api.Action
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Internal as GradleInternal
 
 sealed class Database : JdbcAware, SettingsElement {
     abstract var username: String
@@ -20,6 +21,7 @@ sealed class Database : JdbcAware, SettingsElement {
         @get:Input override var port: Int = 5432,
         @get:Nested override val jdbc: Jdbc = Jdbc(),
     ) : Database() {
+        @GradleInternal
         internal fun getJdbcUrl(host: String, port: Int) = "${jdbc.schema}://$host:$port/$name${jdbc.urlQueryParams}"
     }
 
@@ -31,6 +33,7 @@ sealed class Database : JdbcAware, SettingsElement {
         @get:Input override var port: Int = 5432,
         @get:Nested override val jdbc: Jdbc = Jdbc(),
     ) : Database() {
+        @GradleInternal
         internal fun getJdbcUrl() = "${jdbc.schema}://$host:$port/$name${jdbc.urlQueryParams}"
     }
 }

--- a/src/main/kotlin/dev/monosoul/jooq/settings/Image.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/settings/Image.kt
@@ -1,10 +1,13 @@
 package dev.monosoul.jooq.settings
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
 data class Image(
-    var name: String = "postgres:14.4-alpine",
-    var envVars: Map<String, String> = mapOf(),
-    var testQuery: String = "SELECT 1",
-    var command: String? = null,
+    @get:Input var name: String = "postgres:14.4-alpine",
+    @get:Input var envVars: Map<String, String> = mapOf(),
+    @get:Input var testQuery: String = "SELECT 1",
+    @get:Input @get:Optional var command: String? = null,
 ) : SettingsElement {
     constructor(database: Database.Internal) : this(
         envVars = mapOf(

--- a/src/main/kotlin/dev/monosoul/jooq/settings/Jdbc.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/settings/Jdbc.kt
@@ -1,7 +1,9 @@
 package dev.monosoul.jooq.settings
 
+import org.gradle.api.tasks.Input
+
 data class Jdbc(
-    var schema: String = "jdbc:postgresql",
-    var driverClassName: String = "org.postgresql.Driver",
-    var urlQueryParams: String = "",
+    @get:Input var schema: String = "jdbc:postgresql",
+    @get:Input var driverClassName: String = "org.postgresql.Driver",
+    @get:Input var urlQueryParams: String = "",
 ) : SettingsElement

--- a/src/main/kotlin/dev/monosoul/jooq/settings/JooqDockerPluginSettings.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/settings/JooqDockerPluginSettings.kt
@@ -8,6 +8,7 @@ import org.testcontainers.shaded.org.apache.commons.lang3.builder.EqualsBuilder.
 import org.testcontainers.shaded.org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode
 
 sealed class JooqDockerPluginSettings : SettingsElement {
+    @get:Nested
     internal abstract val database: Database
     internal abstract fun runWithDatabaseCredentials(
         classloaders: CodegenClasspathAwareClassLoaders,
@@ -17,10 +18,8 @@ sealed class JooqDockerPluginSettings : SettingsElement {
     internal abstract fun copy(): JooqDockerPluginSettings
 
     class WithContainer private constructor(
-        @get:Nested
         override val database: Database.Internal,
-        @get:Nested
-        internal val image: Image,
+        @get:Nested internal val image: Image,
     ) : JooqDockerPluginSettings(), DbAware<Database.Internal>, ImageAware {
         private constructor(database: Database.Internal) : this(database, Image(database))
         constructor(customizer: Action<WithContainer> = Action<WithContainer> { }) : this(Database.Internal()) {
@@ -65,7 +64,6 @@ sealed class JooqDockerPluginSettings : SettingsElement {
     }
 
     class WithoutContainer private constructor(
-        @get:Nested
         override val database: Database.External
     ) : JooqDockerPluginSettings(), DbAware<Database.External> {
         constructor(customizer: Action<WithoutContainer> = Action<WithoutContainer> { }) : this(Database.External()) {

--- a/src/main/kotlin/dev/monosoul/jooq/settings/JooqDockerPluginSettings.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/settings/JooqDockerPluginSettings.kt
@@ -3,6 +3,7 @@ package dev.monosoul.jooq.settings
 import dev.monosoul.jooq.container.GenericDatabaseContainer
 import dev.monosoul.jooq.util.CodegenClasspathAwareClassLoaders
 import org.gradle.api.Action
+import org.gradle.api.tasks.Nested
 import org.testcontainers.shaded.org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals
 import org.testcontainers.shaded.org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode
 
@@ -16,7 +17,9 @@ sealed class JooqDockerPluginSettings : SettingsElement {
     internal abstract fun copy(): JooqDockerPluginSettings
 
     class WithContainer private constructor(
+        @get:Nested
         override val database: Database.Internal,
+        @get:Nested
         internal val image: Image,
     ) : JooqDockerPluginSettings(), DbAware<Database.Internal>, ImageAware {
         private constructor(database: Database.Internal) : this(database, Image(database))
@@ -62,6 +65,7 @@ sealed class JooqDockerPluginSettings : SettingsElement {
     }
 
     class WithoutContainer private constructor(
+        @get:Nested
         override val database: Database.External
     ) : JooqDockerPluginSettings(), DbAware<Database.External> {
         constructor(customizer: Action<WithoutContainer> = Action<WithoutContainer> { }) : this(Database.External()) {


### PR DESCRIPTION
Fixes deprecation features warning that was caused by plugin settings having `equals()` and `hashCode()` implemented.