### PR TITLE
fix: prevent SAXParseException on codegen config deserialization

### DIFF
--- a/src/main/kotlin/dev/monosoul/jooq/codegen/ConfigurationProvider.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/codegen/ConfigurationProvider.kt
@@ -54,7 +54,7 @@ internal class ConfigurationProvider(
         config.generator.apply {
             withLogging(Logging.DEBUG)
             withTarget(codeGenTarget())
-            nonNullStrategy.nonNullMatchers.apply(schemaToPackageMapping.get().toMappingApplier())
+            nonNullStrategy.apply(schemaToPackageMapping.get().toMappingApplier())
         }
     }
 
@@ -73,9 +73,10 @@ internal class ConfigurationProvider(
             .withOutputSchemaToDefault(outputSchemaToDefault.get().contains(schemaName))
     }
 
-    private fun Map<String, String>.toMappingApplier(): (Matchers) -> Unit = { matchers ->
+    private fun Map<String, String>.toMappingApplier(): (Strategy) -> Unit = { strategy ->
         if (isNotEmpty()) {
-            matchers
+            strategy
+                .nonNullMatchers
                 .withSchemas(*toSchemasMatchers())
                 .withCatalogs(*toCatalogMatchers())
         }

--- a/src/test/kotlin/dev/monosoul/jooq/functional/JavaBasedConfigJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/JavaBasedConfigJooqDockerPluginFunctionalTest.kt
@@ -14,6 +14,8 @@ class JavaBasedConfigJooqDockerPluginFunctionalTest : JooqDockerPluginFunctional
         // given
         prepareBuildGradleFile {
             """
+                import org.jooq.meta.jaxb.Strategy
+                
                 plugins {
                     id("dev.monosoul.jooq-docker")
                 }
@@ -27,6 +29,9 @@ class JavaBasedConfigJooqDockerPluginFunctionalTest : JooqDockerPluginFunctional
                         schemas.set(listOf("public", "other"))
                         usingJavaConfig {
                             database.withExcludes("BAR")
+                            withStrategy(
+                                Strategy().withName("org.jooq.codegen.KeepNamesGeneratorStrategy")
+                            )
                         }
                     }
                 }
@@ -48,10 +53,10 @@ class JavaBasedConfigJooqDockerPluginFunctionalTest : JooqDockerPluginFunctional
         expect {
             that(result).generateJooqClassesTask.outcome isEqualTo SUCCESS
             that(
-                projectFile("build/generated-jooq/org/jooq/generated/public_/tables/Foo.java")
+                projectFile("build/generated-jooq/org/jooq/generated/public_/tables/foo.java")
             ).exists()
             that(
-                projectFile("build/generated-jooq/org/jooq/generated/other/tables/Bar.java")
+                projectFile("build/generated-jooq/org/jooq/generated/other/tables/bar.java")
             ).notExists()
         }
     }


### PR DESCRIPTION
jOOQ's generator strategy configuration should either have a strategy name specified, or a set of matchers, but not both. `org.jooq.meta.jaxb.Strategy` has default strategy name specified that is ignored in runtime, but not ignored by `org.jooq.util.jaxb.tools.MiniJAXB`. Thus, if the `Strategy` was configured with matchers and then serialized, the serialized config will have both matchers and default strategy name causing `SAXParseException` on deserialization.

This PR does 2 things:

- makes sure we don't create an empty `Matchers` element for `Strategy`
- sanitizes codegen config on serialization to make sure default strategy name is never serialized

Fixes #100 