### PR TITLE
fix: wrap generatorConfig and pluginSettings into a private value holder

### DIFF
--- a/artifact-tests/src/test/kotlin/dev/monosoul/jooq/artifact/JooqCodegenLoggingLevelsTest.kt
+++ b/artifact-tests/src/test/kotlin/dev/monosoul/jooq/artifact/JooqCodegenLoggingLevelsTest.kt
@@ -96,16 +96,24 @@ class JooqCodegenLoggingLevelsTest {
         withCopyToContainer(
             Transferable.of(
                 """
-                    rootProject.name = "testproject"
-
                     pluginManagement {
                         repositories {
                             maven {
                                 name = "localBuild"
                                 url = uri("./local-repository")
                             }
-                            gradlePluginPortal()
                             mavenCentral()
+                            gradlePluginPortal {
+                                content {
+                                    excludeGroup("org.jooq")
+                                    excludeGroup("org.flywaydb")
+                                    excludeGroupByRegex("com\\.fasterxml.*")
+                                    excludeGroupByRegex("com\\.google.*")
+                                    excludeGroupByRegex("org\\.junit.*")
+                                    excludeGroupByRegex("net\\.java.*")
+                                    excludeGroupByRegex("jakarta.*")
+                                }
+                            }
                         }
                     }
                 """.trimIndent()

--- a/artifact-tests/src/test/resources/testproject/settings.gradle.kts
+++ b/artifact-tests/src/test/resources/testproject/settings.gradle.kts
@@ -6,7 +6,17 @@ pluginManagement {
             name = "localBuild"
             url = uri("./local-repository")
         }
-        gradlePluginPortal()
         mavenCentral()
+        gradlePluginPortal {
+            content {
+                excludeGroup("org.jooq")
+                excludeGroup("org.flywaydb")
+                excludeGroupByRegex("com\\.fasterxml.*")
+                excludeGroupByRegex("com\\.google.*")
+                excludeGroupByRegex("org\\.junit.*")
+                excludeGroupByRegex("net\\.java.*")
+                excludeGroupByRegex("jakarta.*")
+            }
+        }
     }
 }

--- a/src/main/kotlin/dev/monosoul/jooq/GenerateJooqClassesTask.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/GenerateJooqClassesTask.kt
@@ -236,4 +236,4 @@ open class GenerateJooqClassesTask @Inject constructor(
     }
 }
 
-private data class PrivateValueHolder<T>(@get:Input val value: T) : ValueHolder<T>()
+private data class PrivateValueHolder<T>(@get:Nested val value: T) : ValueHolder<T>()

--- a/src/main/kotlin/dev/monosoul/jooq/ValueHolder.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/ValueHolder.kt
@@ -1,0 +1,10 @@
+package dev.monosoul.jooq
+
+import java.io.Serializable
+
+/**
+ * Sealed value class having a single private implementation.
+ *
+ * Provides a way to make some task input API stricter.
+ */
+sealed class ValueHolder<T> : Serializable

--- a/src/test/kotlin/dev/monosoul/jooq/functional/ImmutableValueHolderJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/ImmutableValueHolderJooqDockerPluginFunctionalTest.kt
@@ -1,0 +1,45 @@
+package dev.monosoul.jooq.functional
+
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.junit.jupiter.api.Test
+import strikt.api.expectThrows
+import strikt.assertions.contains
+
+class ImmutableValueHolderJooqDockerPluginFunctionalTest : JooqDockerPluginFunctionalTestBase() {
+
+    @Test
+    fun `should not be possible to create an instance of ValueHolder by extending it from Groovy`() {
+        // given
+        prepareBuildGradleFile("build.gradle") {
+            // language=gradle
+            """
+                import dev.monosoul.jooq.ValueHolder
+                
+                plugins {
+                    id "dev.monosoul.jooq-docker"
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    jooqCodegen "org.postgresql:postgresql:42.3.6"
+                }
+                
+                class InternalValueHolder<T> extends ValueHolder<T> {}
+                
+                new InternalValueHolder<String>()
+            """.trimIndent()
+        }
+
+        // when & then
+        expectThrows<UnexpectedBuildFailure> {
+            runGradleWithArguments("tasks")
+        }.get { stackTraceToString() }.contains(
+            "Caused by: java.lang.IllegalAccessError: " +
+                    "class InternalValueHolder tried to access private method " +
+                    "'void dev.monosoul.jooq.ValueHolder.<init>()'"
+        )
+    }
+}


### PR DESCRIPTION
Since Gradle task inputs must be public, there's no way to easily prevent direct modifications of `generatorConfig` and `pluginSettings` values. This change introduces a sealed value class with a single private implementation, that is used to wrap `generatorConfig` and `pluginSettings` values. Since it is impossible to instantiate `ValueHolder` or access the value it holds, this change makes using configuration methods provided by the task the only way to configure those values.