### PR TITLE
fix: downgrade testcontainers to 1.18.1

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 jooq = "3.18.5"
 flyway = "9.20.1"
-testcontainers = "1.18.3"
+testcontainers = "1.18.1"
 jna = "5.13.0"
 
 [libraries]


### PR DESCRIPTION
Testcontainers `1.18.2` to `1.18.3` seems to sometimes cause an issue on M1/M2 Macs where Docker environment can not be found at all, regardless of configuration options, making it totally unusable.

The issue is reported here: testcontainers/testcontainers-java#7082

When using the plugin with Docker Desktop make sure to enable default Docker socket:
![image](https://github.com/monosoul/jooq-gradle-plugin/assets/5037832/b4136de3-59b9-4e5f-8b10-578f1a5b450b)
