### PR TITLE
fix: prevent cache invalidation due to project directory change

### DIFF
--- a/src/main/kotlin/dev/monosoul/jooq/GenerateJooqClassesTask.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/GenerateJooqClassesTask.kt
@@ -13,6 +13,7 @@ import dev.monosoul.jooq.settings.JooqDockerPluginSettings.WithoutContainer
 import dev.monosoul.jooq.settings.SettingsAware
 import dev.monosoul.jooq.util.CodegenClasspathAwareClassLoaders
 import dev.monosoul.jooq.util.callWith
+import dev.monosoul.jooq.util.copy
 import dev.monosoul.jooq.util.getCodegenLogging
 import groovy.lang.Closure
 import org.gradle.api.Action
@@ -162,7 +163,6 @@ open class GenerateJooqClassesTask
         private val configurationProvider =
             ConfigurationProvider(
                 basePackageName = basePackageName,
-                outputDirectory = outputDirectory,
                 outputSchemaToDefault = outputSchemaToDefault,
                 schemaToPackageMapping = schemaToPackageMapping,
                 schemas = schemas,
@@ -254,7 +254,7 @@ open class GenerateJooqClassesTask
             codegenRunner.generateJooqClasses(
                 codegenAwareClassLoader = jdbcAwareClassLoader,
                 configuration =
-                    _generatorConfig.get().value.postProcess(
+                    _generatorConfig.get().value.copy().postProcess(
                         schemaVersion = schemaVersion,
                         credentials = credentials,
                         extraTableExclusions =
@@ -262,6 +262,7 @@ open class GenerateJooqClassesTask
                                 migrationRunner.flywayTableName.takeUnless { includeFlywayTable.get() },
                             ),
                     ),
+                outputDirectory = outputDirectory,
             )
         }
 

--- a/src/main/kotlin/dev/monosoul/jooq/codegen/ConfigurationProvider.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/codegen/ConfigurationProvider.kt
@@ -2,7 +2,6 @@ package dev.monosoul.jooq.codegen
 
 import dev.monosoul.jooq.migration.SchemaVersion
 import dev.monosoul.jooq.settings.DatabaseCredentials
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileContents
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
@@ -28,7 +27,6 @@ import java.io.InputStream
 
 internal class ConfigurationProvider(
     private val basePackageName: Property<String>,
-    private val outputDirectory: DirectoryProperty,
     private val outputSchemaToDefault: SetProperty<String>,
     private val schemaToPackageMapping: MapProperty<String, String>,
     private val schemas: ListProperty<String>,
@@ -66,7 +64,7 @@ internal class ConfigurationProvider(
     private fun codeGenTarget() =
         Target()
             .withPackageName(basePackageName.get())
-            .withDirectory(outputDirectory.asFile.get().toString())
+            .withDirectory("./generated-jooq-placeholder")
             .withEncoding("UTF-8")
             .withClean(true)
 

--- a/src/main/kotlin/dev/monosoul/jooq/codegen/UniversalJooqCodegenRunner.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/codegen/UniversalJooqCodegenRunner.kt
@@ -2,6 +2,7 @@ package dev.monosoul.jooq.codegen
 
 import dev.monosoul.jooq.JooqDockerPlugin.Companion.CONFIGURATION_NAME
 import dev.monosoul.jooq.util.CodegenClasspathAwareClassLoaders
+import org.gradle.api.file.DirectoryProperty
 import org.jooq.meta.jaxb.Configuration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -12,7 +13,10 @@ internal class UniversalJooqCodegenRunner {
     fun generateJooqClasses(
         codegenAwareClassLoader: CodegenClasspathAwareClassLoaders,
         configuration: Configuration,
+        outputDirectory: DirectoryProperty,
     ) {
+        configuration.generator.target.directory = outputDirectory.asFile.get().toString()
+
         runCatching {
             ReflectiveJooqCodegenRunner(codegenAwareClassLoader.buildscriptExclusive)
         }.onFailure {

--- a/src/main/kotlin/dev/monosoul/jooq/util/ConfigurationCopy.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/util/ConfigurationCopy.kt
@@ -1,0 +1,20 @@
+package dev.monosoul.jooq.util
+
+import org.jooq.meta.jaxb.Configuration
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+
+internal fun Configuration.copy(): Configuration {
+    val serialized =
+        ByteArrayOutputStream().apply {
+            ObjectOutputStream(this).use { oos ->
+                oos.writeObject(this@copy)
+            }
+        }.toByteArray()
+
+    return ObjectInputStream(ByteArrayInputStream(serialized)).use { ois ->
+        ois.readObject() as Configuration
+    }
+}

--- a/src/test/kotlin/dev/monosoul/jooq/functional/CacheJooqDockerPluginFunctionalTest.kt
+++ b/src/test/kotlin/dev/monosoul/jooq/functional/CacheJooqDockerPluginFunctionalTest.kt
@@ -2,6 +2,7 @@ package dev.monosoul.jooq.functional
 
 import org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import strikt.api.expect
@@ -13,10 +14,27 @@ class CacheJooqDockerPluginFunctionalTest : JooqDockerPluginFunctionalTestBase()
     @TempDir
     private lateinit var localBuildCacheDirectory: File
 
+    @TempDir
+    private lateinit var siblingProjectDir: File
+
+    @BeforeEach
+    fun siblingSetUp() {
+        siblingProjectDir.copy(from = "/testkit-gradle.properties", to = "gradle.properties")
+    }
+
     @Test
     fun `should load generateJooqClasses task output from cache`() {
         // given
-        configureLocalGradleCache()
+        writeProjectFile("settings.gradle.kts") {
+            """
+            buildCache {
+                local {
+                    directory = "${localBuildCacheDirectory.path}"
+                }
+            }
+            """.trimIndent()
+        }
+
         prepareBuildGradleFile {
             """
             plugins {
@@ -61,15 +79,63 @@ class CacheJooqDockerPluginFunctionalTest : JooqDockerPluginFunctionalTestBase()
         }
     }
 
-    private fun configureLocalGradleCache() {
-        writeProjectFile("settings.gradle.kts") {
-            """
-            buildCache {
-                local {
-                    directory = "${localBuildCacheDirectory.path}"
-                }
+    @Test
+    fun `sibling project in a different directory should have the same cache hash`() {
+        // given
+        """
+        buildCache {
+            local {
+                directory = "${localBuildCacheDirectory.path}"
             }
-            """.trimIndent()
+        }
+        """.trimIndent().also {
+            writeProjectFile("settings.gradle.kts") { it }
+            siblingProjectDir.writeBuildGradleFile("settings.gradle.kts") { it }
+        }
+
+        """
+        plugins {
+            id("dev.monosoul.jooq-docker")
+        }
+
+        repositories {
+            mavenCentral()
+        }
+
+        dependencies {
+            jooqCodegen("org.postgresql:postgresql:42.3.6")
+        }
+        """.trimIndent().also {
+            prepareBuildGradleFile { it }
+            siblingProjectDir.writeBuildGradleFile { it }
+        }
+
+        copyResource(from = "/V01__init.sql", to = "src/main/resources/db/migration/V01__init.sql")
+        siblingProjectDir.copy(from = "/V01__init.sql", to = "src/main/resources/db/migration/V01__init.sql")
+
+        // when
+        // run from the first project loads to cache
+        val resultWithoutCache = runGradleWithArguments("generateJooqClasses", "--build-cache")
+
+        // run from the sibling project uses the cache
+        val resultFromCache =
+            runGradleWithArguments(
+                "generateJooqClasses",
+                "--build-cache",
+                projectDirectory = siblingProjectDir,
+            )
+
+        // then
+        expect {
+            that(resultWithoutCache).generateJooqClassesTask.outcome isEqualTo SUCCESS
+            that(resultFromCache).generateJooqClassesTask.outcome isEqualTo FROM_CACHE
+
+            that(
+                projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java"),
+            ).exists()
+            that(
+                siblingProjectDir.getChild("build/generated-jooq/org/jooq/generated/tables/Foo.java"),
+            ).exists()
         }
     }
 }


### PR DESCRIPTION
Fixes #127 

Previously, since output dir was stored in the codegen configuration in addition to the task property, Gradle build cache was not reusable when project is built on different machines. This change fixes that by providing output dir at later stage.