### PR TITLE
feat: add support for setting target source set

### DIFF
--- a/src/main/kotlin/dev/monosoul/jooq/GenerateJooqClassesTask.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/GenerateJooqClassesTask.kt
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.listProperty
@@ -54,6 +55,12 @@ open class GenerateJooqClassesTask
         private val projectLayout: ProjectLayout,
     ) : DefaultTask(),
         SettingsAware {
+        /**
+         * Source set name to include generated sources into.
+         */
+        @Input
+        val targetSourceSet = objectFactory.property<String>().convention(MAIN_SOURCE_SET_NAME)
+
         /**
          * List of schemas to take into account when running migrations and generating code.
          */

--- a/src/main/kotlin/dev/monosoul/jooq/JooqDockerPlugin.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/JooqDockerPlugin.kt
@@ -7,7 +7,6 @@ import org.gradle.api.attributes.Bundling
 import org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.ProviderFactory
-import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.named
@@ -42,9 +41,13 @@ open class JooqDockerPlugin
                 tasks.register<GenerateJooqClassesTask>("generateJooqClasses")
                 pluginManager.withPlugin("org.gradle.java") {
                     extensions.findByType<JavaPluginExtension>()?.run {
-                        sourceSets.named(MAIN_SOURCE_SET_NAME) {
+                        sourceSets.configureEach {
                             java {
-                                srcDirs(tasks.withType<GenerateJooqClassesTask>())
+                                srcDirs(
+                                    tasks
+                                        .withType<GenerateJooqClassesTask>()
+                                        .matching { it.targetSourceSet.get() == this@configureEach.name },
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
This PR introduces support for setting target source set for each `GenerateJooqClassesTask` instance.

Source sets are configured right after the plugin is applied, but before the build script (project) is evaluated, so source set configuration happens before any values are set in the buildscript. This means a project extension can't be used to configure the source set name for the plugin to generate sources for (the source set will be configured before `targetSourceSet` value is set). Therefore I took a different approach here: we configure all source sets to include `GenerateJooqClassesTask` tasks output where `targetSourceSet` value of the task matches the source set name.

This way it is possible to avoid using something like `project.afterEvaluate` to configure source sets and configuration still happens lazily.

Fixes #213 