### PR TITLE
fix: add support for SQLite URLs

### DIFF
--- a/src/main/kotlin/dev/monosoul/jooq/settings/Database.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/settings/Database.kt
@@ -3,6 +3,7 @@ package dev.monosoul.jooq.settings
 import org.gradle.api.Action
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.Internal as GradleInternal
 
 sealed class Database :
@@ -42,11 +43,20 @@ sealed class Database :
         override var username: String = "postgres",
         override var password: String = "postgres",
         override var name: String = "postgres",
-        @get:Input var host: String = "localhost",
+        @get:Input
+        @get:Optional
+        var host: String? = "localhost",
         override var port: Int = 5432,
         override val jdbc: Jdbc = Jdbc(),
     ) : Database() {
+        private fun hostAndPort() =
+            if (host != null) {
+                "$host:$port/"
+            } else {
+                ""
+            }
+
         @GradleInternal
-        internal fun getJdbcUrl() = "${jdbc.schema}://$host:$port/$name${jdbc.urlQueryParams}"
+        internal fun getJdbcUrl() = "${jdbc.schema}://${hostAndPort()}$name${jdbc.urlQueryParams}"
     }
 }


### PR DESCRIPTION
This makes `host` parameter optional in external DB creds since SQLite DBs are just files