### PR TITLE
build: migrate publishing OSSRH -> central

### DIFF
--- a/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
@@ -26,8 +26,8 @@ signing {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
     transitionCheckOptions {


### PR DESCRIPTION
Migrate publishing from OSSRH to Maven central portal.

See: https://central.sonatype.org/pages/ossrh-eol/