### PR TITLE
fix: make the plugin compatible with Isolated projects

### DIFF
--- a/src/extraTest/kotlin/dev/monosoul/jooq/functional/IsolatedProjectsJooqDockerPluginFunctionalTest.kt
+++ b/src/extraTest/kotlin/dev/monosoul/jooq/functional/IsolatedProjectsJooqDockerPluginFunctionalTest.kt
@@ -1,0 +1,48 @@
+package dev.monosoul.jooq.functional
+
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import strikt.api.expect
+import strikt.assertions.contains
+import strikt.assertions.isEqualTo
+import strikt.java.exists
+import strikt.java.notExists
+import java.io.File
+
+class IsolatedProjectsJooqDockerPluginFunctionalTest : FunctionalTestBase() {
+    @Test
+    fun `should work with isolated projects enabled`() {
+        // given
+        prepareBuildGradleFile {
+            """
+            plugins {
+                id("dev.monosoul.jooq-docker")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                jooqCodegen("org.postgresql:postgresql:42.3.6")
+            }
+            """.trimIndent()
+        }
+        copyResource(from = "/V01__init.sql", to = "src/main/resources/db/migration/V01__init.sql")
+
+        // when
+        val result = runGradleWithArguments("generateJooqClasses", "--isolated-projects")
+
+        // then
+        expect {
+            that(result).apply {
+                generateJooqClassesTask.outcome isEqualTo SUCCESS
+            }
+            that(
+                projectFile("build/generated-jooq/org/jooq/generated/tables/Foo.java"),
+            ).exists()
+        }
+    }
+}

--- a/src/main/kotlin/dev/monosoul/jooq/JooqDockerPlugin.kt
+++ b/src/main/kotlin/dev/monosoul/jooq/JooqDockerPlugin.kt
@@ -28,15 +28,7 @@ open class JooqDockerPlugin
                 }
                 extensions.create<JooqExtension>(
                     "jooq",
-                    providerFactory.provider {
-                        // TODO: this is a workaround for https://github.com/gradle/gradle/issues/21876
-                        project.properties.entries
-                            .filter { (key, _) ->
-                                key.startsWith(PropertiesReader.PREFIX)
-                            }.mapNotNull { (key, value) ->
-                                (value as? String)?.let { key to it }
-                            }.toMap()
-                    },
+                    providerFactory.gradlePropertiesPrefixedBy(PropertiesReader.PREFIX),
                 )
                 tasks.register<GenerateJooqClassesTask>("generateJooqClasses")
                 pluginManager.withPlugin("org.gradle.java") {


### PR DESCRIPTION
BREAKING CHANGE: the plugin is now incompatible with Gradle versions below 8.0

Makes the plugin compatible with [Isolated projects](https://docs.gradle.org/current/userguide/isolated_projects.html) in Gradle.

Fixes #398 